### PR TITLE
Fixed CLUT movement bugs and added HiDPI display support

### DIFF
--- a/PsxVram-SDL.c
+++ b/PsxVram-SDL.c
@@ -86,7 +86,8 @@ void drawRect(SDL_Surface * surBlank, SDL_Surface * sur, SDL_Rect * rect, line *
 	//clutLine
 	clutSpeed = (mode == SDL_PIXELFORMAT_INDEX8) ? CLUT_SIZE_8BPP : CLUT_SIZE_4BPP;
 	l = clutLine->length;
-	xl = clutLine->startCoord.x = clamp((clutLine->startCoord.x & ~(clutSpeed - 1)), 0, VRAM_WIDTH - l + 1);
+	//xl = clutLine->startCoord.x = clamp((clutLine->startCoord.x & ~(clutSpeed - 1)), 0, VRAM_WIDTH - l + 1);
+	xl = clutLine->startCoord.x = clamp(clutLine->startCoord.x, 0, VRAM_WIDTH - l + 1);
 	yl = clutLine->startCoord.y = clamp(clutLine->startCoord.y, 0, VRAM_HEIGHT);
 	//clear clutLine
 	rectBig.x = xl - clutSpeed;
@@ -434,8 +435,9 @@ readFile:
 			 */
 			if ((event.key.keysym.mod & KMOD_CTRL) != 0 && ((event.key.keysym.mod & KMOD_SHIFT) == 0)) {
 				rectSpeed = 1;
-			} else
+			} else {
 				rectSpeed = 8;
+			}
 
 			switch (event.key.keysym.sym) {
 			case SDLK_ESCAPE:
@@ -491,11 +493,11 @@ readFile:
 				clutLine.startCoord.y += rectSpeed;
 				break;
 			case SDLK_LEFT:
-				clutLine.startCoord.x -= clutSpeed;
+				clutLine.startCoord.x -= rectSpeed;
 				//align position GPU can address only full clut coords, which lessens possible clut positions
 				break;
 			case SDLK_RIGHT:
-				clutLine.startCoord.x += clutSpeed;
+				clutLine.startCoord.x += rectSpeed;
 				break;
 			}
 

--- a/PsxVram-SDL.c
+++ b/PsxVram-SDL.c
@@ -341,7 +341,7 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
-	window = SDL_CreateWindow("VRAM overview", SDL_WINDOWPOS_UNDEFINED, 32, VRAM_WIDTH, VRAM_HEIGHT, SDL_WINDOW_SHOWN);
+	window = SDL_CreateWindow("VRAM overview", SDL_WINDOWPOS_UNDEFINED, 32, VRAM_WIDTH, VRAM_HEIGHT, SDL_WINDOW_SHOWN | SDL_WINDOW_ALLOW_HIGHDPI);
 	winSur = SDL_GetWindowSurface(window);
 
 	if (getFileName(fileName, window, argc, argv) == 0) {
@@ -350,7 +350,7 @@ int main(int argc, char *argv[])
 	}
 	//mode view window:     
 	SDL_GetWindowPosition(window, &x, &y);
-	window2 = SDL_CreateWindow("Mode viewer", SDL_WINDOWPOS_UNDEFINED, y + VRAM_HEIGHT, VRAM_WIDTH, VRAM_HEIGHT, SDL_WINDOW_SHOWN);
+	window2 = SDL_CreateWindow("Mode viewer", SDL_WINDOWPOS_UNDEFINED, y + VRAM_HEIGHT, VRAM_WIDTH, VRAM_HEIGHT, SDL_WINDOW_SHOWN | SDL_WINDOW_ALLOW_HIGHDPI);
 	winSur2 = SDL_GetWindowSurface(window2);
 
 	pInBuffer = (u16 *) malloc(VRAM_WIDTH * VRAM_HEIGHT * sizeof(u16));


### PR DESCRIPTION
I fixed a bug which would prevent the CLUT and the rectangle from moving 1 pixel at a time when holding control.
I also added support for HiDPI displays like Apple's MacBooks.  Without the extra SDL_WINDOW_ALLOW_HIGHDPI flag, the window looks blurry and is not pixel-precise.